### PR TITLE
Prune events

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,12 +138,8 @@ The `Toggle` component dispatches a "toggle" event.
 ## Forwarded events
 
 - on:click
-- on:mouseover
-- on:mouseenter
-- on:mouseout
 - on:focus
 - on:blur
-- on:keydown
 
 ## TypeScript
 

--- a/src/Toggle.svelte
+++ b/src/Toggle.svelte
@@ -134,12 +134,8 @@
       {disabled}
       on:click
       on:click={() => (toggled = !toggled)}
-      on:mouseover
-      on:mouseenter
-      on:mouseout
       on:focus
-      on:blur
-      on:keydown />
+      on:blur />
     <slot {toggled}>
       {#if on && off}<span>{toggled ? on : off}</span>{/if}
     </slot>

--- a/test.svelte
+++ b/test.svelte
@@ -12,13 +12,13 @@
   on:toggle={(e) => {
     console.log(e.detail); // boolean
   }}
-  on:click={e => {
+  on:click={(e) => {
     console.log(e); // MouseEvent
   }}
-  on:focus={e => {
+  on:focus={(e) => {
     console.log(e); // FocusEvent
   }}
-  on:blur={e => {
+  on:blur={(e) => {
     console.log(e); // FocusEvent
   }} />
 

--- a/test.svelte
+++ b/test.svelte
@@ -10,7 +10,16 @@
   on="On"
   off="Off"
   on:toggle={(e) => {
-    console.log(e.detail);
+    console.log(e.detail); // boolean
+  }}
+  on:click={e => {
+    console.log(e); // MouseEvent
+  }}
+  on:focus={e => {
+    console.log(e); // FocusEvent
+  }}
+  on:blur={e => {
+    console.log(e); // FocusEvent
   }} />
 
 <Toggle let:toggled={isToggled}>

--- a/types/Toggle.d.ts
+++ b/types/Toggle.d.ts
@@ -59,12 +59,8 @@ export default class Toggle extends SvelteComponentTyped<
   {
     toggle: CustomEvent<boolean>;
     click: WindowEventMap["click"];
-    mouseover: WindowEventMap["mouseover"];
-    mouseenter: WindowEventMap["mouseenter"];
-    mouseout: WindowEventMap["mouseout"];
     focus: WindowEventMap["focus"];
     blur: WindowEventMap["blur"];
-    keydown: WindowEventMap["keydown"];
   },
   { default: { toggled: boolean } }
 > {}


### PR DESCRIPTION
**Breaking Changes**

- remove forwarded mouse, keydown events from `Toggle`