### PR TITLE
fix(package): include `exports` map

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,21 @@
   "svelte": "./src/index.js",
   "main": "./src/index.js",
   "types": "./src/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./src/index.d.ts",
+      "svelte": "./src/index.js",
+      "default": "./src/index.js"
+    },
+    "./src/*.svelte": {
+      "types": "./src/*.svelte.d.ts",
+      "import": "./src/*.svelte"
+    },
+    "./src/*": {
+      "types": "./src/*.d.ts",
+      "import": "./src/*.js"
+    }
+  },
   "scripts": {
     "dev": "rollup -cw",
     "predeploy": "rollup -c",


### PR DESCRIPTION
Thanks for the handy component!

[vite-plugin-svelte](https://github.com/sveltejs/vite-plugin-svelte) currently gives this warning:

```
8:59:10 AM [vite-plugin-svelte] WARNING: The following packages have a svelte field in their package.json but no exports condition for svelte.

svelte-toggle@4.0.0

Please see https://github.com/sveltejs/vite-plugin-svelte/blob/main/docs/faq.md#missing-exports-condition for details.
```

Apparently the `"svelte": ...` field in package.json is deprecated in favor of the newer "[conditional exports](https://nodejs.org/api/packages.html#conditional-exports)" mechanism.

This PR adds the appropriate `"exports"` field as discussed at https://github.com/sveltejs/vite-plugin-svelte/blob/main/docs/faq.md#missing-exports-condition